### PR TITLE
Replace Actual365NoLeap() with Actual365Fixed(Actual365Fixed::NoLeap)

### DIFF
--- a/QuantLibAddin/gensrc/metadata/enumerations/enumeratedtypes.xml
+++ b/QuantLibAddin/gensrc/metadata/enumerations/enumeratedtypes.xml
@@ -742,19 +742,19 @@
         <!-- NON-ISDA -->
         <EnumeratedType>
           <string>Actual/365 (No Leap)</string>
-          <value>QuantLib::Actual365NoLeap()</value>
+          <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
         </EnumeratedType>
         <EnumeratedType>
           <string>Actual/365 (JGB)</string>
-          <value>QuantLib::Actual365NoLeap()</value>
+          <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
         </EnumeratedType>
         <EnumeratedType>
           <string>Act/365 (NL)</string>
-          <value>QuantLib::Actual365NoLeap()</value>
+          <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
         </EnumeratedType>
         <EnumeratedType>
           <string>NL/365</string>
-          <value>QuantLib::Actual365NoLeap()</value>
+          <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
         </EnumeratedType>
 
         <!-- NON-ISDA QuantLib specific -->


### PR DESCRIPTION
This change is required since https://github.com/lballabio/QuantLib/pull/625 removed `Actual365NoLeap()`.

Not sure on which branch to base this. I'm guessing you probably need to create a new `v1.16.x` branch?