### PR TITLE
Implement qlScheduleFullInterfaceFromDateVector in order to create schedule with full interface from date vector

### DIFF
--- a/QuantLibAddin/gensrc/metadata/functions/schedule.xml
+++ b/QuantLibAddin/gensrc/metadata/functions/schedule.xml
@@ -361,6 +361,60 @@
       </ParameterList>
     </Constructor>
 
+    <Constructor name='qlScheduleFullInterfaceFromDateVector'>
+      <libraryFunction>Schedule</libraryFunction>
+      <SupportedPlatforms>
+        <!--SupportedPlatform name='Excel' calcInWizard='false'/-->
+        <SupportedPlatform name='Excel'/>
+        <SupportedPlatform name='Calc'/>
+        <SupportedPlatform name='Cpp'/>
+      </SupportedPlatforms>
+      <ParameterList>
+        <Parameters>
+          <Parameter name='Dates' default='QuantLib::Date()'>
+            <type>QuantLib::Date</type>
+            <tensorRank>vector</tensorRank>
+            <description>date vector.</description>
+          </Parameter>
+          <Parameter name='IsRegular' default='true'>
+            <type>bool</type>
+            <tensorRank>vector</tensorRank>
+            <description>boolean vector.</description>
+          </Parameter>
+          <Parameter name='Tenor' exampleValue='6M'>
+            <type>QuantLib::Period</type>
+            <tensorRank>scalar</tensorRank>
+            <description>tenor (e.g. 2D for two days , 3W for three weeks, 6M for six months, 1Y for one year).</description>
+          </Parameter>
+          <Parameter name='Calendar' default='"NullCalendar"'>
+            <type>QuantLib::Calendar</type>
+            <tensorRank>scalar</tensorRank>
+            <description>holiday calendar (e.g. TARGET).</description>
+          </Parameter>
+          <Parameter name='Convention' default='"Unadjusted"'>
+            <type>QuantLib::BusinessDayConvention</type>
+            <tensorRank>scalar</tensorRank>
+            <description>accrual dates business day convention.</description>
+          </Parameter>
+          <Parameter name='TermDateConv' default='"Unadjusted"'>
+            <type>QuantLib::BusinessDayConvention</type>
+            <tensorRank>scalar</tensorRank>
+            <description>termination date business day convention.</description>
+          </Parameter>
+          <Parameter name='GenRule' default='"Backward"'>
+            <type>QuantLib::DateGeneration::Rule</type>
+            <tensorRank>scalar</tensorRank>
+            <description>Date generation rule (Backward, Forward, ThirdWednesday, Twentieth, TwentiethIMM, Zero).</description>
+          </Parameter>
+          <Parameter name='EndOfMonth' default='false'>
+            <type>bool</type>
+            <tensorRank>scalar</tensorRank>
+            <description>end of month convention. Ignored for Tenor below 1M.</description>
+          </Parameter>
+        </Parameters>
+      </ParameterList>
+    </Constructor>
+
     <Constructor name='qlScheduleTruncated'>
       <libraryFunction>Schedule</libraryFunction>
       <SupportedPlatforms>

--- a/QuantLibAddin/qlo/schedule.cpp
+++ b/QuantLibAddin/qlo/schedule.cpp
@@ -64,6 +64,36 @@ namespace QuantLibAddin {
     }
 
     Schedule::Schedule(const boost::shared_ptr<ObjectHandler::ValueObject>& p,
+        const std::vector<QuantLib::Date>& dates,
+        const std::vector<bool>& isRegular,
+        const QuantLib::Period& tenor,
+        const QuantLib::Calendar& calendar,
+        const QuantLib::BusinessDayConvention convention,
+        const QuantLib::BusinessDayConvention terminationDateConvention,
+        QuantLib::DateGeneration::Rule rule,
+        bool endOfMonth,
+        bool permanent)
+    : ObjectHandler::LibraryObject<QuantLib::Schedule>(p, permanent) {
+
+        boost::optional<QuantLib::BusinessDayConvention> optionalTerminationDateConvention(terminationDateConvention);
+        boost::optional<QuantLib::Period> optionalTenor(tenor);
+        boost::optional<QuantLib::DateGeneration::Rule> optionalRule(rule);
+        boost::optional<bool> optionalEndOfMonth(endOfMonth);
+
+        QuantLib::Schedule schedule(dates,
+            calendar,
+            convention,
+            optionalTerminationDateConvention,
+            optionalTenor,
+            optionalRule,
+            optionalEndOfMonth,
+            isRegular);
+
+        libraryObject_ = boost::shared_ptr<QuantLib::Schedule>(new
+            QuantLib::Schedule(schedule));
+    }
+
+    Schedule::Schedule(const boost::shared_ptr<ObjectHandler::ValueObject>& p,
                        const boost::shared_ptr<QuantLib::Schedule>& from,
                        const QuantLib::Date& truncationDate,
                        bool permanent)

--- a/QuantLibAddin/qlo/schedule.hpp
+++ b/QuantLibAddin/qlo/schedule.hpp
@@ -56,6 +56,17 @@ namespace QuantLibAddin {
             bool permanent);
         Schedule(
             const boost::shared_ptr<ObjectHandler::ValueObject>& properties,
+            const std::vector<QuantLib::Date>& dates,
+            const std::vector<bool>& isRegular,
+            const QuantLib::Period& tenor,
+            const QuantLib::Calendar& calendar,
+            QuantLib::BusinessDayConvention convention,
+            QuantLib::BusinessDayConvention terminationDateConvention,
+            QuantLib::DateGeneration::Rule rule,
+            bool endOfMonth,
+            bool permanent);
+        Schedule(
+            const boost::shared_ptr<ObjectHandler::ValueObject>& properties,
             const boost::shared_ptr<QuantLib::Schedule>& originalSchedule,
             const QuantLib::Date& truncationDate,
             bool permanent);


### PR DESCRIPTION
Implement qlScheduleFullInterfaceFromDateVector in order to create schedule with full interface from date vector

Again, this should probably be based on a `v1.16.x` branch, when it's created.