### PR TITLE
Correct "No Leap" day count

### DIFF
--- a/QuantLibAddin/gensrc/metadata/enumerations/enumeratedtypes.xml
+++ b/QuantLibAddin/gensrc/metadata/enumerations/enumeratedtypes.xml
@@ -742,19 +742,19 @@
         <!-- NON-ISDA -->
         <EnumeratedType>
           <string>Actual/365 (No Leap)</string>
-          <value>QuantLib::Actual365NoLeap()</value>
+          <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
         </EnumeratedType>
         <EnumeratedType>
           <string>Actual/365 (JGB)</string>
-          <value>QuantLib::Actual365NoLeap()</value>
+          <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
         </EnumeratedType>
         <EnumeratedType>
           <string>Act/365 (NL)</string>
-          <value>QuantLib::Actual365NoLeap()</value>
+          <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
         </EnumeratedType>
         <EnumeratedType>
           <string>NL/365</string>
-          <value>QuantLib::Actual365NoLeap()</value>
+          <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
         </EnumeratedType>
 
         <!-- NON-ISDA QuantLib specific -->


### PR DESCRIPTION
Actual365NoLeap deprecated in favour Actual365Fixed from QL V1.16