### PR TITLE
Add QuantLib as an explicit submodule, tagged at v1.17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Compilation artifacts
-QuantLib/
 ObjectHandler/Docs/auto.pages/
 ObjectHandler/build/
 ObjectHandler/gensrc/build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "QuantLib"]
+	path = QuantLib
+	url = https://github.com/lballabio/QuantLib


### PR DESCRIPTION
Hi Eric,

This just a suggestion to make QuantLib an explicit submodule of this repo. In this I'm basing this PR on v1.17 and therefor the QuantLib submodule is also refereced against the v1.17 release. 

This will avoid having to manually clone and checkout the appropriate QuantLib version. 

Can you see any disadvantages of this approach?