### PR TITLE
Update descriptions with correct ZeroYield value instead of ZeroRate

### DIFF
--- a/QuantLibAddin/gensrc/metadata/functions/correlation.xml
+++ b/QuantLibAddin/gensrc/metadata/functions/correlation.xml
@@ -217,7 +217,7 @@
           <Parameter name='TraitsID' default='"Discount"'>
             <type>string</type>
             <tensorRank>scalar</tensorRank>
-            <description>Discount, ZeroRate, or ForwardRate.</description>
+            <description>Discount, ZeroYield, or ForwardRate.</description>
           </Parameter>
           <Parameter name='InterpolatorID' default='"CubicSpline"'>
             <type>string</type>

--- a/QuantLibAddin/gensrc/metadata/functions/piecewiseyieldcurve.xml
+++ b/QuantLibAddin/gensrc/metadata/functions/piecewiseyieldcurve.xml
@@ -72,7 +72,7 @@
           <Parameter name='TraitsID' default='"Discount"'>
             <type>string</type>
             <tensorRank>scalar</tensorRank>
-            <description>Discount, ZeroRate, or ForwardRate.</description>
+            <description>Discount, ZeroYield, or ForwardRate.</description>
           </Parameter>
           <Parameter name='InterpolatorID' default='"LogLinear"'>
             <type>string</type>
@@ -132,7 +132,7 @@
           <Parameter name='TraitsID' default='"Discount"'>
             <type>string</type>
             <tensorRank>scalar</tensorRank>
-            <description>Discount, ZeroRate, or ForwardRate.</description>
+            <description>Discount, ZeroYield, or ForwardRate.</description>
           </Parameter>
           <Parameter name='InterpolatorID' default='"LogLinear"'>
             <type>string</type>


### PR DESCRIPTION
Descriptions currently state that `ZeroRate` is a valid value, where it should actually be `ZeroYield`