### PR TITLE
Add more aliases for Actual/365 (No Leap) day counter

### DIFF
--- a/QuantLibAddin/gensrc/metadata/enumerations/enumeratedtypes.xml
+++ b/QuantLibAddin/gensrc/metadata/enumerations/enumeratedtypes.xml
@@ -758,11 +758,23 @@
           <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
         </EnumeratedType>
         <EnumeratedType>
+          <string>Actual/365 (NL)</string>
+          <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
+        </EnumeratedType>
+        <EnumeratedType>
           <string>Actual/365 (JGB)</string>
           <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
         </EnumeratedType>
         <EnumeratedType>
           <string>Act/365 (NL)</string>
+          <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
+        </EnumeratedType>
+        <EnumeratedType>
+          <string>A/365 (NL)</string>
+          <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
+        </EnumeratedType>
+        <EnumeratedType>
+          <string>A/365NL</string>
           <value>QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap)</value>
         </EnumeratedType>
         <EnumeratedType>


### PR DESCRIPTION
This PR brings the `No Leap` aliases in line with the `Fixed` aliases of `Actual/365`.

Because I always forget the current set of aliases for `No Leap`!