### PR TITLE
Edited FunctionCall constructor

### DIFF
--- a/ObjectHandler/ohxl/functioncall.cpp
+++ b/ObjectHandler/ohxl/functioncall.cpp
@@ -34,7 +34,9 @@ namespace ObjectHandler {
             callerDimensions_(CallerDimensions::Uninitialized),
             error_(false) {
         OH_REQUIRE(!instance_, "Multiple attempts to initialize global FunctionCall object");
-        instance_ = this;
+        
+        //DS 19-Nov-20 Moved this line to after the Excel block, in case an exception is thrown
+        //instance_ = this;
 
         Excel(xlfCaller, &xCaller_, 0);
         if (xCaller_->xltype == xltypeRef || xCaller_->xltype == xltypeSRef) {
@@ -48,6 +50,8 @@ namespace ObjectHandler {
         } else {
             callerType_ = CallerType::Unknown;
         }
+
+        instance_ = this;
     }
 
     FunctionCall::~FunctionCall() {


### PR DESCRIPTION
Moved the code that sets the singleton instance pointer in the constructor to after a block that may throw an exception. This will prevent the constructor setting the instance and blocking further calls via OH_REQUIRE in the event of an exception.