### PR TITLE
Upgrade gensrc to python3

### DIFF
--- a/gensrc/gensrc.py
+++ b/gensrc/gensrc.py
@@ -48,7 +48,7 @@ usage: %(scriptName)s -[flags] --oh_dir
     ObjectHandler source code tree."""
 
 def usage():
-    print USAGE_ERROR % { 'scriptName' : sys.argv[0] }
+    print(USAGE_ERROR % { 'scriptName' : sys.argv[0] })
     sys.exit(1)
 
 # set the error handler

--- a/gensrc/gensrc/addins/doxygen.py
+++ b/gensrc/gensrc/addins/doxygen.py
@@ -83,10 +83,10 @@ class Doxygen(addin.Addin):
     def generateEnums(self):
         """Generate documentation for enumerations."""
         bufClassLinks = ''
-        for i in xrange(self.enumerationList_.enumeratedClassGroupsCount()):
+        for i in range(self.enumerationList_.enumeratedClassGroupsCount()):
             bufClassLinks += Doxygen.LINE_REF_CLASS % i
         bufTypeLinks = ''
-        for i in xrange(self.enumerationList_.enumeratedTypeGroupsCount()):
+        for i in range(self.enumerationList_.enumeratedTypeGroupsCount()):
             bufTypeLinks += Doxygen.LINE_REF_TYPE % i
         bufClassDocs = ''
         i = 0

--- a/gensrc/gensrc/addins/excel.py
+++ b/gensrc/gensrc/addins/excel.py
@@ -34,6 +34,7 @@ from gensrc.utilities import log
 
 import re
 import string
+from functools import reduce
 
 # Constants
 
@@ -61,7 +62,7 @@ CELL_MAX_COL_NUM = 16384        # value XFD expressed as base 26 number
 CELL_MAX_ROW_NUM = 1048576      # the last row in Excel 2007
 CELL_NAME_REGEX = re.compile(r'(?P<colLabel>[A-Z]+)(?P<rowLabel>\d+)', re.I)
 # We need the 1-based index of letters so prefix the alphabet with a dummy character
-COL_TO_NUM = "_" + string.lowercase
+COL_TO_NUM = "_" + string.ascii_lowercase
 
 class ExcelAddin(addin.Addin):
     """Generate source code for Excel addin."""
@@ -117,7 +118,7 @@ class ExcelAddin(addin.Addin):
 
     def indexOfCol(self, str):
         """Convert an Excel column ID to an int"""
-        return reduce(lambda x, y: 26 * x + y, map(COL_TO_NUM.index, str.lower()))
+        return reduce(lambda x, y: 26 * x + y, list(map(COL_TO_NUM.index, str.lower())))
 
     def cellNameConflict(self, funcName):
         """Return a boolean indicating whether the given function name

--- a/gensrc/gensrc/categories/category.py
+++ b/gensrc/gensrc/categories/category.py
@@ -42,7 +42,7 @@ class Category(serializable.Serializable):
 
     def platformSupported(self, platformName, implementation):
         """Determine whether this category is supported for given platform."""
-        for func in self.functions_.values():
+        for func in list(self.functions_.values()):
             if func.platformSupported(platformName, implementation):
                 return True
 
@@ -109,7 +109,7 @@ class Category(serializable.Serializable):
         """Perform post serialization initialization."""
         self.generateVOs_ = False
         self.containsLoopFunction_ = False
-        for func in self.functions_.values():
+        for func in list(self.functions_.values()):
             if func.generateVOs():
                 self.generateVOs_ = True
             if func.loopParameter():
@@ -126,7 +126,7 @@ class Category(serializable.Serializable):
         ret = ''
         if environment.config().usingEnumerations():
             enumIncludes = []
-            for func in self.functions_.values():
+            for func in list(self.functions_.values()):
                 if constructorOnly and not func.generateVOs(): continue
                 enumIncludes.extend(enumerationList.enumIncludes(
                     func.parameterList().parameters()))

--- a/gensrc/gensrc/categories/categorylist.py
+++ b/gensrc/gensrc/categories/categorylist.py
@@ -45,7 +45,7 @@ class CategoryList(object):
                     yield cat
 
     def init(self, enumerationList):
-        for cat in self.categoryDict_.values():
+        for cat in list(self.categoryDict_.values()):
             cat.init(enumerationList)
 
     #############################################
@@ -56,7 +56,7 @@ class CategoryList(object):
         if not configPath: return
         for categoryName in catList:
             cat = utilities.serializeObject(category.Category, configPath + 'metadata/functions/' + categoryName)
-            if self.categoryDict_.has_key(cat.name()):
+            if cat.name() in self.categoryDict_:
                 raise exceptions.DuplicateNameException(cat.name())
             self.categoryDict_[cat.name()] = cat
     

--- a/gensrc/gensrc/enumerations/enumeratedtypes.py
+++ b/gensrc/gensrc/enumerations/enumeratedtypes.py
@@ -116,7 +116,7 @@ class EnumeratedTypeGroup(serializable.Serializable):
 
     def postSerialize(self):
         """Invoke any post serialization behavior that may be required."""
-        for enumeratedType in self.enumeratedTypes_.values():
+        for enumeratedType in list(self.enumeratedTypes_.values()):
             enumeratedType.setType(self.type_)
             enumeratedType.setConstructor(self.constructor_)
 

--- a/gensrc/gensrc/enumerations/enumerationlist.py
+++ b/gensrc/gensrc/enumerations/enumerationlist.py
@@ -82,7 +82,7 @@ class EnumerationList(object):
             xmlEnumTypes.serializeObjectDict(self, enumeratedtypes.EnumeratedTypeGroup)
             xmlEnumTypes.serializeProperty(self, common.ENUM_TYPE_COPYRIGHT)
             self.hasEnumeratedTypes = True
-            for item in self.enumeratedTypeGroups_.values():
+            for item in list(self.enumeratedTypeGroups_.values()):
                 self.typeDict_[item.type()] = item.includeFile()
         else:
             self.hasEnumeratedTypes = False
@@ -92,7 +92,7 @@ class EnumerationList(object):
             xmlEnumClasses.serializeObjectDict(self, enumeratedclasses.EnumeratedClassGroup)
             xmlEnumClasses.serializeProperty(self, common.ENUM_CLASS_COPYRIGHT)
             self.hasEnumeratedClasses = True
-            for item in self.enumeratedClassGroups_.values():
+            for item in list(self.enumeratedClassGroups_.values()):
                 self.typeDict_[item.className()] = item.includeFile()
         else:
             self.hasEnumeratedClasses= False
@@ -102,7 +102,7 @@ class EnumerationList(object):
             xmlEnumPairs.serializeObjectDict(self, enumeratedpairs.EnumeratedPairGroup)
             xmlEnumPairs.serializeProperty(self, common.ENUM_PAIR_COPYRIGHT)
             self.hasEnumeratedPairs = True
-            for item in self.enumeratedPairGroups_.values():
+            for item in list(self.enumeratedPairGroups_.values()):
                 self.typeDict_[item.className()] = item.includeFile()
         else:
             self.hasEnumeratedPairs = False
@@ -114,7 +114,7 @@ class EnumerationList(object):
         ret = []
         for p in parameterList:
             if p.fullType().superType() == common.ENUM \
-            and self.typeDict_.has_key(p.fullType().value()):
+            and p.fullType().value() in self.typeDict_:
                 ret.append(self.typeDict_[p.fullType().value()])
         return ret
 

--- a/gensrc/gensrc/functions/function.py
+++ b/gensrc/gensrc/functions/function.py
@@ -51,21 +51,21 @@ class Function(serializable.Serializable):
 
     def platformSupported(self, platformName, implementation):
         """Determine whether this function supported by given platform."""
-        return self.supportedPlatforms_.has_key(platformName) \
+        return platformName in self.supportedPlatforms_ \
             and self.supportedPlatforms_[platformName].implNum() >= implementation
 
     def xlMacro(self):
         """Determine whether this function requires macro on excel platform."""
-        return self.supportedPlatforms_.has_key('Excel') \
+        return 'Excel' in self.supportedPlatforms_ \
             and self.supportedPlatforms_['Excel'].xlMacro()
 
     def calcInWizard(self):
         """Determine whether to calc this function under the Excel Function Wizard."""
-        return self.supportedPlatforms_.has_key('Excel') \
+        return 'Excel' in self.supportedPlatforms_ \
             and self.supportedPlatforms_['Excel'].calcInWizard()
 
     def supportedPlatforms(self):
-        return ', '.join(self.supportedPlatforms_.keys()).replace('Cpp', 'C++')
+        return ', '.join(list(self.supportedPlatforms_.keys())).replace('Cpp', 'C++')
 
     def parameterList(self):
         return self.parameterList_

--- a/gensrc/gensrc/parameters/parameter.py
+++ b/gensrc/gensrc/parameters/parameter.py
@@ -128,15 +128,15 @@ class Value(serializable.Serializable):
 
     def printDebug(self):
         """For debugging purposes, write the properties of this parameter to stdout."""
-        print "type=" + str(type(self))
-        print "name=" + self.printValue(self.name_)
-        print "tensorRank=" + self.printValue(self.tensorRank_)
-        print "type=" + self.printValue(self.type_)
-        print "loop=" + self.printValue(self.loop_)
-        print "vecIter=" + self.printValue(self.vectorIterator_)
-        print "default=" + self.printValue(self.default_)
-        print "ignore=" + self.printValue(self.ignore_)
-        print "const=" + self.printValue(self.const_)
+        print("type=" + str(type(self)))
+        print("name=" + self.printValue(self.name_))
+        print("tensorRank=" + self.printValue(self.tensorRank_))
+        print("type=" + self.printValue(self.type_))
+        print("loop=" + self.printValue(self.loop_))
+        print("vecIter=" + self.printValue(self.vectorIterator_))
+        print("default=" + self.printValue(self.default_))
+        print("ignore=" + self.printValue(self.ignore_))
+        print("const=" + self.printValue(self.const_))
 
 class Parameter(Value):
     """Encapsulate state necessary to generate source code

--- a/gensrc/gensrc/patterns/singleton.py
+++ b/gensrc/gensrc/patterns/singleton.py
@@ -27,16 +27,15 @@ class MetaSingleton(type):
     """Meta type for the Singleton class."""
 
     def __new__(metaclass, strName, tupBases, dict):
-        if dict.has_key('__new__'):
+        if '__new__' in dict:
             raise exceptions.SingletonOverrideNewException()
         return super(MetaSingleton,metaclass).__new__(metaclass, strName, tupBases, dict)
         
     def __call__(cls, *lstArgs, **dictArgs):
         raise exceptions.SingletonCallException()
 
-class Singleton(object):
+class Singleton(object, metaclass=MetaSingleton):
     """Implementation of the Singleton pattern."""
-    __metaclass__ = MetaSingleton
     
     def instance(cls):
         """Call this to instantiate an instance or retrieve the existing instance."""

--- a/gensrc/gensrc/rules/rule.py
+++ b/gensrc/gensrc/rules/rule.py
@@ -34,7 +34,7 @@ import codedict
 
 def getCode(codeID):
     """Retrieve the requested item from module codedict.py"""
-    if codedict.__dict__.has_key(codeID):
+    if codeID in codedict.__dict__:
         return codedict.__dict__[codeID]
     else:
         raise exceptions.RuleCodeInvalidException(codeID)
@@ -80,8 +80,8 @@ class Rule(serializable.Serializable):
         return self.code_
 
     def printDebug(self):
-        print self.tensorRank_, self.superType_, self.nativeType_, self.type_, \
-            self.default_, self.loop_, self.code_
+        print(self.tensorRank_, self.superType_, self.nativeType_, self.type_, \
+            self.default_, self.loop_, self.code_)
 
     #############################################
     # serializer interface
@@ -216,11 +216,11 @@ class RuleGroup(serializable.Serializable):
 
     def printDebug(self):
         """Write debug information to stdout."""
-        print "debug rule group *****"
-        print self.name_, self.delimiter_, self.checkParameterIgnore_, \
-            self.checkSkipFirst_, self.indent_
+        print("debug rule group *****")
+        print(self.name_, self.delimiter_, self.checkParameterIgnore_, \
+            self.checkSkipFirst_, self.indent_)
         for ruleItem in self.rules_:
-            print "print rule item: *****"
+            print("print rule item: *****")
             ruleItem.printDebug()
 
     #############################################

--- a/gensrc/gensrc/serialization/factory.py
+++ b/gensrc/gensrc/serialization/factory.py
@@ -53,7 +53,7 @@ class Factory(singleton.Singleton):
 
     def makeObject(self, className):
         """Construct an object given its class name."""
-        if self.creators_.has_key(className):
+        if className in self.creators_:
             return self.creators_[className]()
         else:
             raise exceptions.SerializationCreatorException(className)

--- a/gensrc/gensrc/serialization/xmlreader.py
+++ b/gensrc/gensrc/serialization/xmlreader.py
@@ -159,7 +159,7 @@ class XmlReader(serializer.Serializer):
             objectInstance.serialize(self)
             objectInstance.postSerialize()
             self.node_ = self.node_.parentNode.parentNode
-            if dict.has_key(objectInstance.name()):
+            if objectInstance.name() in dict:
                 raise exceptions.SerializationDuplicateKeyException(self.documentName_, objectInstance.name())
             dict[objectInstance.name()] = objectInstance
             keys.append(objectInstance.name())

--- a/gensrc/gensrc/types/typelist.py
+++ b/gensrc/gensrc/types/typelist.py
@@ -51,10 +51,10 @@ class TypeList(object):
         If the FullType has already been derived then return it.  If not then
         construct it, add it to the dict of known FullTypes, and return it."""
 
-        if self.fullTypeDict_.has_key((dataTypeName, superTypeName)):
+        if (dataTypeName, superTypeName) in self.fullTypeDict_:
             return self.fullTypeDict_[dataTypeName, superTypeName]
 
-        if self.dataTypeDict_.dataTypes().has_key(dataTypeName):
+        if dataTypeName in self.dataTypeDict_.dataTypes():
             dataType = self.dataTypeDict_.dataTypes()[dataTypeName]
         else:
             raise exceptions.InvalidTypeNameException(dataTypeName)
@@ -64,7 +64,7 @@ class TypeList(object):
         else:
             superTypeNameEffective = dataType.defaultSuperType()
 
-        if self.superTypeDict_.superTypes().has_key(superTypeNameEffective):
+        if superTypeNameEffective in self.superTypeDict_.superTypes():
             superType = self.superTypeDict_.superTypes()[superTypeNameEffective]
         else:
             raise exceptions.InvalidSuperTypeNameException(superTypeNameEffective)

--- a/gensrc/gensrc/utilities/log.py
+++ b/gensrc/gensrc/utilities/log.py
@@ -27,5 +27,5 @@ class Log(singleton.Singleton):
     def logMessage(self, message = ''):
         """Print a message to stdout."""
         #print time.strftime('%d-%b-%Y %H:%M:%S ') + message
-        print message
+        print(message)
 

--- a/gensrc/gensrc/utilities/outputfile.py
+++ b/gensrc/gensrc/utilities/outputfile.py
@@ -86,7 +86,7 @@ class OutputFile(object):
         self.addin_ = addin
         self.fileName_ = fileName
         self.fileNameTemp_ = self.fileName_ + '.temp'
-        self.outFile_ = file(self.fileNameTemp_, 'w')
+        self.outFile_ = open(self.fileNameTemp_, 'w')
         if copyright:
             self.printCopyright(copyright)
         if printHeader:


### PR DESCRIPTION
Preliminary python3 support for the gensrc scripts. I didn't dig very deep. I used the `2to3` tool and then manually fixed a few additional issues. Building `QuantLibXL` now works fine using the `python3` interpreter, but I can't say for sure whether all changes across all the files have been changed.

My suggestion is we merge this and then fix the additional issues as they arise. As far as I understand, besides the Excel plugin, this repo isn't really used for anything else anymore.