### PR TITLE
Include round brackets in regex

### DIFF
--- a/ObjectHandler/ohxl/rangereference.cpp
+++ b/ObjectHandler/ohxl/rangereference.cpp
@@ -41,7 +41,7 @@ namespace ObjectHandler {
     void RangeReference::initializeRegexes() {
 
         std::ostringstream strStandard, strSpecial;
-        strStandard << "=?'?.*\\[([\\.\\w\\s-]+)(?:\\.XLS)?\\]([\\w\\s]+)'?!" 
+        strStandard << "=?'?.*\\[([\\.\\w\\s()-]+)(?:\\.XLS)?\\]([\\w\\s]+)'?!" 
             << Configuration::instance().rowCharacter() << "(\\d*)" 
             << Configuration::instance().colCharacter() << "(\\d*)(?::" 
             << Configuration::instance().rowCharacter() << "(\\d*)" 


### PR DESCRIPTION
I had an Excel file with the filename `SwapBondForFloatingRateNote(AutoRecovered).xlsm` for which the regex was failing due to the round brackets.



