### PR TITLE
Relax regex conditions to capture more characters in filenames

### DIFF
--- a/ObjectHandler/ohxl/rangereference.cpp
+++ b/ObjectHandler/ohxl/rangereference.cpp
@@ -41,12 +41,21 @@ namespace ObjectHandler {
     void RangeReference::initializeRegexes() {
 
         std::ostringstream strStandard, strSpecial;
-        strStandard << "=?'?.*\\[([\\.\\w\\s()-]+)(?:\\.XLS)?\\]([\\w\\s]+)'?!" 
+
+        const char* extensions = "(?:\\.XLS[XMB]?)";
+
+        strStandard << "=?'?[^']*\\[([^']+?)"
+            << extensions
+            << "?" // extension is optional
+            << "\\]([^']+)'?!"
             << Configuration::instance().rowCharacter() << "(\\d*)" 
             << Configuration::instance().colCharacter() << "(\\d*)(?::" 
             << Configuration::instance().rowCharacter() << "(\\d*)" 
             << Configuration::instance().colCharacter() << "(\\d*))?";
-        strSpecial << "=?'?([\\w\\s]+)(?:\\.XLS)'?!" 
+
+        strSpecial << "=?'?([^']+?)"
+            << extensions
+            << "'?!"
             << Configuration::instance().rowCharacter() << "(\\d*)" 
             << Configuration::instance().colCharacter() << "(\\d*)(?::" 
             << Configuration::instance().rowCharacter() << "(\\d*)" 


### PR DESCRIPTION
Hi

I happened to bump into more cases where the regexes were failing. So I made some changes:
- Accommodate all Excel file extensions: .xls, .xlsx, .xlsm, .xlsb
- Accept any character except `'` in book and sheet names.
- Other refactoring, like the `extensions` variable.